### PR TITLE
Add ci for our monorepo setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,7 @@ insert_final_newline = true
 charset = utf-8
 indent_style = tab
 indent_size = 4
+
+[*.yaml]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/cicd-go.yaml
+++ b/.github/workflows/cicd-go.yaml
@@ -1,0 +1,150 @@
+name: 'CICD Go'
+
+on:
+  workflow_call:
+    inputs:
+      service:
+        description: 'The name of the service.'
+        type: string
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+# We cannot use the global "defaults" syntax. ${{ inputs.service }} will not resolve.
+# defaults:
+#   run:
+#     working-directory: services/${{ inputs.service }}
+
+env:
+  GO_VERSION: '1.19'
+
+jobs:
+
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/${{ inputs.service }}
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - uses: actions/checkout@v3
+
+      - name: Cache build dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/_go.sum') }}
+
+      - uses: golangci/golangci-lint-action@v3
+        with:
+          # Can this be a bug in golangci-lint? We already defined the working-directory for this step.
+          working-directory: services/${{ inputs.service }}
+
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/${{ inputs.service }}
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - uses: actions/checkout@v3
+
+      - name: Cache build dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/_go.sum') }}
+
+      - name: Install dependencies
+        run: go get .
+
+      - name: Test
+        run: go test -v -race ./...
+
+  docker:
+    needs: [ lint, test ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Lowercase github.repository_owner
+        run: |
+          echo "REPOSITORY_OWNER_LC=${REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
+        env:
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+
+      - name: Image name
+        run: |
+          echo "IMAGE_NAME=ghcr.io/${{ env.REPOSITORY_OWNER_LC }}/${{ inputs.service }}" >>${GITHUB_ENV}
+
+      - uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=edge
+            type=ref,event=pr
+            type=ref,event=branch,prefix=branch-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - uses: docker/setup-qemu-action@v2
+
+      - uses: docker/setup-buildx-action@v2
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - id: commit
+        uses: pr-mpt/actions-commit-hash@v2
+        with:
+          commit: "${{ github.sha }}"
+
+      - name: Build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile.service
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          build-args: |
+            SERVICE=${{ inputs.service }}
+            VERSION=${{ steps.commit.outputs.short }}
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Check manifest
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,0 +1,70 @@
+name: cicd
+
+on:
+  push:
+    branches: [ '*' ]
+    tags: [ 'v*' ]
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      services: ${{ steps.aggregate-changes.outputs.services }}
+    steps:
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Detected changes in libs
+        id: changes-in-libs
+        uses: tj-actions/changed-files@v35
+        with:
+          files: |
+            libs/**
+            
+            -   name: Detected changes in services
+                id: changes-in-services
+                uses: tj-actions/changed-files@v35
+                with:
+                    files: |
+                        services/**
+            
+            -   name: Aggregate changes
+                id: aggregate-changes
+                run: |
+                    if [[ "$libsChanged" == "true" ]]; then
+                      echo "services=$(ls services | uniq | jq -R . | jq -sc .)" >> $GITHUB_OUTPUT
+                    else
+                      echo "services=$(echo $changesInServices | awk -F / '$1 ~ /services/ {print $2}' | uniq | jq -R . | jq -sc .)" >> $GITHUB_OUTPUT
+                    fi
+                env:
+                    libsChanged: ${{ steps.changes-in-libs.outputs.any_changed }}
+                    changesInServices: ${{ steps.changes-in-services.outputs.all_changed_files }}
+            
+            -   name: Summarize
+                run: |
+                    echo "services: $services" >> $GITHUB_STEP_SUMMARY
+                env:
+                    services: ${{ steps.aggregate-changes.outputs.services }}
+
+  cicd-go:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.services != '[]' && needs.detect-changes.outputs.services != '' }}
+    strategy:
+      matrix:
+        service: ${{ fromJson(needs.detect-changes.outputs.services) }}
+    permissions:
+      contents: read
+      pull-requests: read
+      packages: write
+    uses: ./.github/workflows/cicd-go.yaml
+    with:
+      service: ${{ matrix.service }}
+    secrets: inherit


### PR DESCRIPTION
Most of `.github/workflows/cicd-go.yaml` is copied over from `helpwave/rest-api` and works as a template for services written in go. `.github/workflows/cicd.yaml` detects and aggregates changes in libs or services and triggers all or specific ci`s.

Closes #30 