### PR TITLE
Initial k8s setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,7 @@ indent_size = 4
 [*.yaml]
 indent_style = space
 indent_size = 2
+
+[*.tf]
+indent_style = space
+indent_size = 2

--- a/kubernetes/emergency-room-svc/helmfile.yaml
+++ b/kubernetes/emergency-room-svc/helmfile.yaml
@@ -1,0 +1,52 @@
+# TOOD: Move away from helmfile. Migrate fully to Terraform.
+
+repositories:
+
+  - name: bitnami
+    url:  https://charts.bitnami.com/bitnami
+
+
+releases:
+
+  # TODO: Move away from one PostgreSQL-Server per service.
+  - name: emergency-room-postgres
+    namespace: emergency-room
+    chart: bitnami/postgresql
+    wait: true
+    set:
+      - name: auth.enablePostgresUser
+        value: true
+      - name: auth.postgresPassword
+        value: helpwave
+      - name: auth.database
+        value: emergency-room
+      - name: auth.username
+        value: helpwave
+      # TODO: Use secrets
+      - name: auth.password
+        value: helpwave
+
+  - name: emergency-room-svc
+    namespace: emergency-room
+    chart: ../service
+    wait: true
+    set:
+      - name: app.name
+        value: emergency-room
+      - name: image.repository
+        value: ghcr.io/helpwave/emergency-room-svc
+      - name: image.tag
+        value: edge
+      - name: image.pullPolicy
+        value: Always
+      - name: postgres.host
+        value: emergency-room-postgres-postgresql.emergency-room
+      - name: postgres.user
+        value: postgres
+      # TODO: Use secrets
+      - name: postgres.password
+        value: helpwave
+      - name: postgres.database
+        value: emergency-room
+      - name: service.enabled
+        value: true

--- a/kubernetes/iac/.gitignore
+++ b/kubernetes/iac/.gitignore
@@ -1,0 +1,34 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/kubernetes/iac/.terraform.lock.hcl
+++ b/kubernetes/iac/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.47.0"
+  constraints = "4.47.0"
+  hashes = [
+    "h1:lLDKVdwuDFlU8AqPX7v2DCwE+EdTYa0YSBTwyu/2LB4=",
+    "zh:030359653ee8e3a7a0ec30f06f7ac0d2bf5cb8bf895d06155646114fa13766e5",
+    "zh:14b18f549466eb99cac08fd2d89c8df3591cc3688c9e5ed12fb4a957482d0e2d",
+    "zh:3a9b9d1878f4004a7fee0ab8f8dea600307ad75a872f591590f704bf504b25af",
+    "zh:412b809bc61a74857912da5c2e9deddf5edf2eb883999ffb29573146ca12097b",
+    "zh:456372baa4fbb397f2d67fa291a15d216937e24dd1c05a66d6484ca2e24829e8",
+    "zh:69dc08f0e8eb672a8be11070b4ebb319b4a1725d928498607a0534a65089f3ef",
+    "zh:bc582257b94b0d2bd225b829016963580c681b09b0545c474420a27909b53fea",
+    "zh:bf1a8bf7e54f3e709d6323bdd12b5bf5cce3b245414f8aa09cb1860aa98f407d",
+    "zh:dc322cd105f3d0d0268e75a646f45471158ac668ed665309483f19c16385783b",
+    "zh:ee3b36c484dd4aea0855300e325fe31eee067eeb759192cee3ccad6fae45f610",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f58ac64cc632d80243c2a97a009c44e8b7672adbab11cce488a77a7efeca33f0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.8.0"
+  constraints = "2.8.0"
+  hashes = [
+    "h1:U0w0mUT0SwZCR0poGNSxGaZJKWcOiu4GerpGztYBiMM=",
+    "zh:1e42d1a04c07d4006844e477ca32b5f45b04f6525dbbbe00b6be6e6ec5a11c54",
+    "zh:2f87187cb48ccfb18d12e2c4332e7e822923b659e7339b954b7db78aff91529f",
+    "zh:391fe49b4d2dc07bc717248a3fc6952189cfc49c596c514ad72a29c9a9f9d575",
+    "zh:89272048e1e63f3edc3e83dfddd5a9fd4bd2a4ead104e67de1e14319294dedf1",
+    "zh:a5a057c3435a854389ce8a1d98a54aaa7cbab68aca7baa436a605897aa70ff7e",
+    "zh:b1098e53e1a8a3afcd325ecd0328662156b3d9c3d80948f19ba3a4eb870cee2b",
+    "zh:b676f949e8274a2b6c3fa41f5428ea597125579c7b93bb50bb73a5e295a7a447",
+    "zh:cdf7e9460f28c2dbfe49a79a5022bd0d474ff18120d340738aa35456ba77ebca",
+    "zh:e24b59b4ed1c593facbf8051ec58550917991e2e017f3085dac5fb902d9908cb",
+    "zh:e3b5e1f5543cac9d9031a028f1c1be4858fb80fae69f181f21e9465e366ebfa2",
+    "zh:e9fddc0bcdb28503078456f0088851d45451600d229975fd9990ee92c7489a10",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/kubernetes/iac/gke.tf
+++ b/kubernetes/iac/gke.tf
@@ -1,0 +1,45 @@
+data "google_client_config" "staging" {}
+
+resource "google_container_cluster" "staging" {
+  name = "helpwave-test-gke-staging"
+  location = var.gcp_zone // zonal cluster
+  
+  remove_default_node_pool = true
+  initial_node_count = 1
+}
+
+resource "google_container_node_pool" "primary_spot_nodes" {
+  name = "primary-spot-nodes"
+  cluster = google_container_cluster.staging.id
+
+  initial_node_count = 2
+  lifecycle {
+    ignore_changes = [
+      initial_node_count
+    ]
+  }
+
+  autoscaling {
+    location_policy = "ANY"
+    min_node_count = 1
+    max_node_count = 3
+  }
+
+  upgrade_settings {
+    max_surge = 1
+    max_unavailable = 0
+  }
+
+  node_config {
+    machine_type = "e2-medium"
+
+    disk_type = "pd-standard"
+    disk_size_gb = 10
+
+    spot = true
+
+    metadata = {
+      "disable-legacy-endpoints" = true
+    }
+  }
+}

--- a/kubernetes/iac/helm.tf
+++ b/kubernetes/iac/helm.tf
@@ -1,0 +1,86 @@
+resource "helm_release" "dapr" {
+  name = "dapr"
+  repository = "https://dapr.github.io/helm-charts"
+  chart = "dapr"
+  version = "1.9.5"
+
+  depends_on = [
+    google_container_cluster.staging
+  ]
+
+  namespace = "dapr-system"
+  create_namespace = true
+
+  set {
+    name = "global.ha.enabled"
+    value = "false"
+  }
+}
+
+resource "helm_release" "nginx" {
+  name = "nginx-ingress"
+  repository = "https://kubernetes.github.io/ingress-nginx"
+  chart = "ingress-nginx"
+  version = "4.4.2"
+
+  depends_on = [
+    google_container_cluster.staging
+  ]
+
+  namespace = "nginx"
+  create_namespace = true
+  
+  set {
+    name = "controller.replicaCount"
+    value = 2
+  }
+
+  set {
+    name = "controller.podAnnotations.dapr\\.io/enabled"
+    value = "true"
+  }
+
+  set {
+    name = "controller.podAnnotations.dapr\\.io/app-id"
+    value = "nginx-ingress"
+  }
+
+  set {
+    name = "controller.podAnnotations.dapr\\.io/app-port"
+    value = "80"
+  }
+
+  set {
+    name = "controller.podAnnotations.dapr\\.io/sidecar-listen-addresses"
+    value = "0.0.0.0"
+  }
+
+  set {
+    name = "controller.service.loadBalancerIP"
+    value = "${var.gcp_public_ipv4}"
+  }
+}
+
+resource "helm_release" "nginx-dapr" {
+  name = "nginx-dapr"
+  chart = "../nginx-dapr"
+
+  depends_on = [
+    google_container_cluster.staging,
+    helm_release.dapr,
+    helm_release.nginx
+  ]
+
+  namespace = "nginx"
+  create_namespace = true
+
+  set {
+    name = "api.staging.hostname"
+    value = "staging.api.helpwave.de"
+  }
+
+  set {
+    name = "nginx.ingressDaprSidecar"
+    value = "nginx-ingress-dapr"
+  }
+}

--- a/kubernetes/iac/providers.tf
+++ b/kubernetes/iac/providers.tf
@@ -1,0 +1,13 @@
+provider "google" {
+  project = var.gcp_project
+  region = var.gcp_region
+  zone = var.gcp_zone
+}
+
+provider "helm" {
+  kubernetes {
+    host  = "https://${google_container_cluster.staging.endpoint}"
+    token = data.google_client_config.staging.access_token
+    cluster_ca_certificate = base64decode(google_container_cluster.staging.master_auth.0.cluster_ca_certificate)
+  }
+}

--- a/kubernetes/iac/variables.tf
+++ b/kubernetes/iac/variables.tf
@@ -1,0 +1,17 @@
+variable "gcp_project" {
+  type = string
+}
+
+variable "gcp_region" {
+  type    = string
+  default = "europe-west3"
+}
+
+variable "gcp_zone" {
+  type    = string
+  default = "europe-west3-b"
+}
+
+variable "gcp_public_ipv4" {
+  type = string
+}

--- a/kubernetes/iac/versions.tf
+++ b/kubernetes/iac/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "4.47.0"
+    }
+
+    helm = {
+      source = "hashicorp/helm"
+      version = "2.8.0"
+    }
+  }
+}

--- a/kubernetes/nginx-dapr/.helmignore
+++ b/kubernetes/nginx-dapr/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kubernetes/nginx-dapr/Chart.yaml
+++ b/kubernetes/nginx-dapr/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: nginx-dapr
+description: Contains an ingress to map traffic for staging to the Dapr sidecar of nginx. Gets consumed by Terraform.
+
+type: application
+
+version: 0.1.0
+
+appVersion: "1.16.0"

--- a/kubernetes/nginx-dapr/templates/_helpers.tpl
+++ b/kubernetes/nginx-dapr/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nginx-dapr.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nginx-dapr.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nginx-dapr.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "nginx-dapr.labels" -}}
+helm.sh/chart: {{ include "nginx-dapr.chart" . }}
+{{ include "nginx-dapr.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nginx-dapr.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nginx-dapr.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nginx-dapr.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "nginx-dapr.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/kubernetes/nginx-dapr/templates/ingress.yaml
+++ b/kubernetes/nginx-dapr/templates/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "nginx-dapr.fullname" . }}
+  labels:
+    {{- include "nginx-dapr.labels" . | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: {{ .Values.api.staging.hostname | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.nginx.ingressDaprSidecar }}
+                port:
+                  number: 80

--- a/kubernetes/nginx-dapr/values.yaml
+++ b/kubernetes/nginx-dapr/values.yaml
@@ -1,0 +1,6 @@
+nginx:
+  ingressDaprSidecar: nginx-ingress-dapr
+
+api:
+  staging:
+    hostname: staging.api.helpwave.de

--- a/kubernetes/service/.helmignore
+++ b/kubernetes/service/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kubernetes/service/Chart.yaml
+++ b/kubernetes/service/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: service
+description: Basic Helm chart for services of helpwave
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/kubernetes/service/templates/NOTES.txt
+++ b/kubernetes/service/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "service.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "service.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "service.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "service.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/kubernetes/service/templates/_helpers.tpl
+++ b/kubernetes/service/templates/_helpers.tpl
@@ -1,0 +1,84 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "postgres.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 54 | trimSuffix "-" }}-postgres
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "service.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "postgres.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 54 | trimSuffix "-" }}-postgres
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 54 | trimSuffix "-" }}-postgres
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 54 | trimSuffix "-" }}-postgres
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "service.labels" -}}
+helm.sh/chart: {{ include "service.chart" . }}
+{{ include "service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "postgres.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "postgres.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "service.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "service.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/kubernetes/service/templates/deployment.yaml
+++ b/kubernetes/service/templates/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "service.fullname" . }}
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+          dapr.io/enabled: {{ .Values.app.dapr | quote }}
+          dapr.io/app-id: {{ .Values.app.name | quote }}
+          dapr.io/app-port: {{ .Values.app.port | quote }}
+      labels:
+        {{- include "service.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "service.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: ['ash', '-c', 'wget -qO migrate.tgz https://github.com/golang-migrate/migrate/releases/download/v4.15.2/migrate.linux-amd64.tar.gz && tar xzf migrate.tgz && POSTGRESQL_URL="postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB?sslmode=disable" && ./migrate -database $POSTGRESQL_URL -path migrations up']
+          env:
+            - name: POSTGRES_HOST
+              value: {{ .Values.postgres.host }}
+            - name: POSTGRES_PORT
+              value: {{ .Values.postgres.port | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.user }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .Values.postgres.password }}
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.database }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: POSTGRES_HOST
+              value: {{ .Values.postgres.host }}
+            - name: POSTGRES_PORT
+              value: {{ .Values.postgres.port | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.user }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .Values.postgres.password }}
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.database }}
+            - name: PORT
+              value: {{ .Values.app.port | quote }}
+            - name: MODE
+              value: {{ .Values.app.env | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/kubernetes/service/templates/hpa.yaml
+++ b/kubernetes/service/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "service.fullname" . }}
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "service.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/kubernetes/service/templates/ingress.yaml
+++ b/kubernetes/service/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "service.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/kubernetes/service/templates/service.yaml
+++ b/kubernetes/service/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "service.fullname" . }}
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: 1337
+      targetPort: 3500
+      protocol: TCP
+      name: dapr-public-lel
+  selector:
+    {{- include "service.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/kubernetes/service/templates/serviceaccount.yaml
+++ b/kubernetes/service/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "service.serviceAccountName" . }}
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/kubernetes/service/templates/tests/test-connection.yaml
+++ b/kubernetes/service/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "service.fullname" . }}-test-connection"
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "service.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/kubernetes/service/values.yaml
+++ b/kubernetes/service/values.yaml
@@ -1,0 +1,76 @@
+replicaCount: 2
+
+postgres:
+  host: localhost
+  port: 5432
+  user: helpwave
+  password: helpwave
+  database: helpwave
+
+app:
+  dapr: true
+  name: service
+  port: 8080
+  env: development
+
+image:
+  repository: helpwave/service
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "edge"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  enabled: false
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/kubernetes/user-svc/helmfile.yaml
+++ b/kubernetes/user-svc/helmfile.yaml
@@ -1,0 +1,52 @@
+# TOOD: Move away from helmfile. Migrate fully to Terraform.
+
+repositories:
+
+  - name: bitnami
+    url:  https://charts.bitnami.com/bitnami
+
+
+releases:
+
+  # TODO: Move away from one PostgreSQL-Server per service.
+  - name: user-postgres
+    namespace: user
+    chart: bitnami/postgresql
+    wait: true
+    set:
+      - name: auth.enablePostgresUser
+        value: true
+      - name: auth.postgresPassword
+        value: helpwave
+      - name: auth.database
+        value: user
+      - name: auth.username
+        value: helpwave
+      # TODO: Use secrets
+      - name: auth.password
+        value: helpwave
+
+  - name: user-svc
+    namespace: user
+    chart: ../service
+    wait: true
+    set:
+      - name: app.name
+        value: user
+      - name: image.repository
+        value: ghcr.io/helpwave/user-svc
+      - name: image.tag
+        value: edge
+      - name: image.pullPolicy
+        value: Always
+      - name: postgres.host
+        value: user-postgres-postgresql.user
+      - name: postgres.user
+        value: postgres
+      # TODO: Use secrets
+      - name: postgres.password
+        value: helpwave
+      - name: postgres.database
+        value: user
+      - name: service.enabled
+        value: true


### PR DESCRIPTION
This pull-request introduces our k8s setup on GKE.
This setup is far away from production ready, but gives us a starting point to build on top.

Directories:
- [/kubernetes/iac](https://github.com/helpwave/services/tree/41-initial-k8s-setup/kubernetes/iac)
	Contains IaC for our GKE cluster on GCP and deploys common/global Helm charts like [Dapr](https://github.com/dapr/helm-charts) and [ingress-nginx](https://github.com/kubernetes/ingress-nginx)
- [/kubernetes/services](https://github.com/helpwave/services/tree/41-initial-k8s-setup/kubernetes/service)
	Contains the Helm chart for our services. Autogenerated with `helm create` and modified for Dapr.
- [/kubernetes/emergency-room-svc](https://github.com/helpwave/services/tree/41-initial-k8s-setup/kubernetes/emergency-room-svc)
	Consumes the services Helm chart and configures that for user-svc. Deploys a [postgresql](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) alongside.
- [/kubernetes/user-svc](https://github.com/helpwave/services/tree/41-initial-k8s-setup/kubernetes/user-svc)
	Consumes the services Helm chart and configures that for emergency-service-svc. Deploys a [postgresql](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) alongside.
- [/kubernetes/nginx-dapr](https://github.com/helpwave/services/tree/41-initial-k8s-setup/kubernetes/nginx-dapr)
	Contains an ingress to map traffic for staging to the Dapr sidecar of nginx. Gets consumed by our IaC.

Moving parts:
- [Terraform](https://github.com/hashicorp/terraform)
	We define our infrastructure on gcp as Iac (Infrastructure-as-Code). Terraform is our tool of choice.
- [helm](https://github.com/helm/helm)
	Templating-Engine and Packet-Manager Kubernetes
- [helmfile](https://github.com/roboll/helmfile)
	Manage multiple Helm charts

Upcoming to-dos which are not part of this pr:
- Move away from helmfile. Migrate fully to Terraform.
- Right now the Helm charts for services are basically the autogenerated from helm with some additions for Dapr and 	migrations. We should clean up these.
- Move away from one PostgreSQL-Server per service.
- Secrets. By whatever method.
- Move IaC to own Repository. Like `helpwave/(iac)`.
- CD to k8s

---

Closes #41 