### PR TITLE
infra: hibernate-gke and cf-dns via terraform

### DIFF
--- a/.github/workflows/hibernate-gke.yaml
+++ b/.github/workflows/hibernate-gke.yaml
@@ -1,0 +1,54 @@
+name: hibernate-gke
+
+on:
+  workflow_dispatch:
+    inputs:
+      zone:
+        description: 'The zone of the cluster'
+        required: true
+        default: 'europe-west3-b'
+      cluster:
+        description: 'The name of the cluster'
+        required: true
+        default: 'helpwave-test-gke-staging'
+      nodePool:
+        description: 'The name of the node-pool inside the cluster'
+        required: true
+        default: 'primary-spot-nodes'
+      numNodes:
+        description: 'The number of nodes for scaling the node-pool up after hibernation'
+        required: false
+        default: '3'
+      desiredState:
+        description: 'The desired state of the cluster. Checked for on. Unchecked for off.'
+        required: true
+        type: boolean
+
+jobs:
+
+  hibernate-gke:
+
+    runs-on: ubuntu-latest
+    steps:
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Turn cluster on or off
+        run: |
+          if [[ "$desiredState" == "true" ]]; then
+            gcloud container clusters resize $cluster --quiet --zone $zone --node-pool $nodePool --num-nodes $numNodes
+          else
+            gcloud container clusters resize $cluster --quiet --zone $zone --node-pool $nodePool --num-nodes 0
+          fi
+        env:
+          zone: ${{ inputs.zone }}
+          cluster: ${{ inputs.cluster }}
+          nodePool: ${{ inputs.nodePool }}
+          numNodes: ${{ inputs.numNodes }}
+          desiredState: ${{ inputs.desiredState }}

--- a/kubernetes/iac/.terraform.lock.hcl
+++ b/kubernetes/iac/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "3.33.1"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:fmfXz46jcHoGPi3BmmQEJZJ0c/Q8xESPwJtmmjnAyr8=",
+    "zh:0387f5891f349fb0ef3b68cbbd212c4c1fabb921324cba4dfeda08ad3d91f338",
+    "zh:3c016161cb8de9fbf1cf7d0d6099fb9c1c0d1e7bcae36a6084285f7fa4726176",
+    "zh:43ea39ca52688c350fccc0207ae49a88835f8c56bbc437999acc7feb04d365fd",
+    "zh:6d184850613b26956634ea5a34c7a0dec775747ef400f83dad54ba48d060218e",
+    "zh:73236e553775b59af1987f6857c68a7c274aea85c21da9e0e8ad6e67ab5318a7",
+    "zh:753e07cbda96d020d5a1fe09beb322e8efeb2d11450c71d956f1ee03d923410c",
+    "zh:7e35d6437fd3add22ebecfe457bfe2f46a2ae58358e59f7ccdb22c13a49fce07",
+    "zh:878d479802ff633e5cc13da6a3b9eb41e572e1320b3ce45662390c8e97167c80",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:950a7489e0394470fd0589121d1a0602c57164c854229fedb3319b717d9c2e23",
+    "zh:a2c3a4b14d4686042e8418860cd59a5f9876c56a755ca9530757307b9b9195cf",
+    "zh:a4dc55555cb79488a8dff002acf4e98061099721571e290b467872f7c30a897f",
+    "zh:b6148bbc97d375f185a2ab05243a4d45da82f0c67033a461179f8090bb8bfbd4",
+    "zh:c0d720c316f580a382d9bc2d00a78217b62fbd28e186dc814bc8d75482540ec2",
+    "zh:dd42c50c4fb93ec390871234f5a52e21aebf91765365c728f3f237c4db4f4748",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/google" {
   version     = "4.47.0"
   constraints = "4.47.0"

--- a/kubernetes/iac/cloudflare.tf
+++ b/kubernetes/iac/cloudflare.tf
@@ -1,0 +1,42 @@
+/*
+resource "cloudflare_account" "helpwave" {
+  name = "helpwave"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "cloudflare_zone" "helpwave-de" {
+  account_id = cloudflare_account.helpwave.id
+  zone = "helpwave.de"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+*/
+
+resource "cloudflare_record" "api-helpwave-de" {
+  zone_id = var.cf_zone_id
+  name = "api"
+  value = google_compute_address.staging-ipv4.address
+  type    = "A"
+  comment = "Managed through Terraform"
+}
+
+resource "cloudflare_record" "staging-helpwave-de" {
+  zone_id = var.cf_zone_id
+  name = "staging"
+  value = cloudflare_record.api-helpwave-de.hostname
+  type = "CNAME"
+  comment = "Managed through Terraform"
+}
+
+resource "cloudflare_record" "staging-api-helpwave-de" {
+  zone_id = var.cf_zone_id
+  name = "staging-api"
+  value = cloudflare_record.api-helpwave-de.hostname
+  type = "CNAME"
+  comment = "Managed through Terraform"
+}

--- a/kubernetes/iac/gcp.tf
+++ b/kubernetes/iac/gcp.tf
@@ -1,0 +1,4 @@
+resource "google_compute_address" "staging-ipv4" {
+  name = "helpwave-test-address-staging"
+  region = var.gcp_region
+}

--- a/kubernetes/iac/gke.tf
+++ b/kubernetes/iac/gke.tf
@@ -3,7 +3,7 @@ data "google_client_config" "staging" {}
 resource "google_container_cluster" "staging" {
   name = "helpwave-test-gke-staging"
   location = var.gcp_zone // zonal cluster
-  
+
   remove_default_node_pool = true
   initial_node_count = 1
 }
@@ -13,17 +13,20 @@ resource "google_container_node_pool" "primary_spot_nodes" {
   cluster = google_container_cluster.staging.id
 
   initial_node_count = 2
+  node_count = 3
   lifecycle {
     ignore_changes = [
       initial_node_count
     ]
   }
 
+  /*
   autoscaling {
     location_policy = "ANY"
     min_node_count = 1
     max_node_count = 3
   }
+  */
 
   upgrade_settings {
     max_surge = 1

--- a/kubernetes/iac/gke.tf
+++ b/kubernetes/iac/gke.tf
@@ -12,7 +12,7 @@ resource "google_container_node_pool" "primary_spot_nodes" {
   name = "primary-spot-nodes"
   cluster = google_container_cluster.staging.id
 
-  initial_node_count = 2
+  // initial_node_count = 2
   node_count = 3
   lifecycle {
     ignore_changes = [

--- a/kubernetes/iac/helm.tf
+++ b/kubernetes/iac/helm.tf
@@ -60,7 +60,7 @@ resource "helm_release" "nginx" {
 
   set {
     name = "controller.service.loadBalancerIP"
-    value = "${var.gcp_public_ipv4}"
+    value = google_compute_address.staging-ipv4.address
   }
 }
 
@@ -79,7 +79,7 @@ resource "helm_release" "nginx-dapr" {
 
   set {
     name = "api.staging.hostname"
-    value = "staging.api.helpwave.de"
+    value = cloudflare_record.staging-api-helpwave-de.hostname
   }
 
   set {

--- a/kubernetes/iac/helm.tf
+++ b/kubernetes/iac/helm.tf
@@ -5,7 +5,8 @@ resource "helm_release" "dapr" {
   version = "1.9.5"
 
   depends_on = [
-    google_container_cluster.staging
+    google_container_cluster.staging,
+    google_container_node_pool.primary_spot_nodes
   ]
 
   namespace = "dapr-system"
@@ -24,12 +25,14 @@ resource "helm_release" "nginx" {
   version = "4.4.2"
 
   depends_on = [
-    google_container_cluster.staging
+    google_container_cluster.staging,
+    google_container_node_pool.primary_spot_nodes,
+    helm_release.dapr
   ]
 
   namespace = "nginx"
   create_namespace = true
-  
+
   set {
     name = "controller.replicaCount"
     value = 2

--- a/kubernetes/iac/outputs.tf
+++ b/kubernetes/iac/outputs.tf
@@ -1,0 +1,3 @@
+output "staging-ipv4" {
+  value = google_compute_address.staging-ipv4.address
+}

--- a/kubernetes/iac/providers.tf
+++ b/kubernetes/iac/providers.tf
@@ -11,3 +11,7 @@ provider "helm" {
     cluster_ca_certificate = base64decode(google_container_cluster.staging.master_auth.0.cluster_ca_certificate)
   }
 }
+
+provider "cloudflare" {
+  api_token = var.cf_api_token
+}

--- a/kubernetes/iac/variables.tf
+++ b/kubernetes/iac/variables.tf
@@ -12,6 +12,10 @@ variable "gcp_zone" {
   default = "europe-west3-b"
 }
 
-variable "gcp_public_ipv4" {
+variable "cf_api_token" {
+  type = string
+}
+
+variable "cf_zone_id" {
   type = string
 }

--- a/kubernetes/iac/versions.tf
+++ b/kubernetes/iac/versions.tf
@@ -9,5 +9,10 @@ terraform {
       source = "hashicorp/helm"
       version = "2.8.0"
     }
+
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 3.0"
+    }
   }
 }


### PR DESCRIPTION
This pull request introduces two new changes, mainly for our infrastructure.

- The required ipv4 and dns changes are managed through Terraform.
- A GitHub Action gets introduces to start and stop/hibernate our gke cluster.

At the moment, the load balancer is not scaled down, which makes sense. The resource is still requested by the control plane. We can improve this in the future by not only scaling the nodes but create and destroy the entire cluster with terraform.