### PR TITLE
fix(ci): use PAT of github.com/helpwave-bot

### DIFF
--- a/.github/workflows/publish-bufs.yaml
+++ b/.github/workflows/publish-bufs.yaml
@@ -69,6 +69,8 @@ jobs:
     steps:
     - name: Clone Repo
       uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.HELPWAVE_BOT_PAT }}
     - uses: actions/setup-node@v3
       with:
         node-version: '18.x'
@@ -99,6 +101,8 @@ jobs:
     steps:
     - name: Clone Repo
       uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.HELPWAVE_BOT_PAT }}
     - name: Install tools
       run: |
         pip install yq


### PR DESCRIPTION
The commit account needs to be in our exception list of users that can push to main. github.com/helpwave-bot is one of them.