### PR TITLE
fix(ci): add `check-preconditions` dependency back

### DIFF
--- a/.github/workflows/publish-bufs.yaml
+++ b/.github/workflows/publish-bufs.yaml
@@ -98,7 +98,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   dart:
-    needs: ts # TODO: Commit all changes in one commit. Should prevents branch behind error as well.
+    needs:
+    - check-preconditions
+    - ts # TODO: Commit all changes in one commit. Should prevents branch behind error as well.
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Likely fixes the root cause for this run failing: https://github.com/helpwave/services/actions/runs/4709945814/jobs/8353316735