### PR TITLE
ci: continue deployments for one service even if others fail

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -100,6 +100,7 @@ jobs:
     needs: detect-changes
     if: ${{ github.event_name != 'pull_request' && needs.detect-changes.outputs.services != '[]' && needs.detect-changes.outputs.services != '' }}
     strategy:
+      fail-fast: false
       matrix:
         service: ${{ fromJson(needs.detect-changes.outputs.services) }}
     uses: ./.github/workflows/fly-deploy.yaml

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -101,6 +101,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && needs.detect-changes.outputs.services != '[]' && needs.detect-changes.outputs.services != '' }}
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         service: ${{ fromJson(needs.detect-changes.outputs.services) }}
     uses: ./.github/workflows/fly-deploy.yaml


### PR DESCRIPTION
## Which issues does this pull request close?
This pul request  closes #195 and also limits to maximum parallel deployments at a time to reduce the load on our [remote builder on Fly](https://fly.io/docs/reference/builders/).

