### PR TITLE
fix: remove invalid placed column attribute

### DIFF
--- a/services/task-svc/internal/patient/models/models.go
+++ b/services/task-svc/internal/patient/models/models.go
@@ -16,6 +16,6 @@ type Patient struct {
 	ID             uuid.UUID             `gorm:"column:id"`
 	OrganizationID uuid.UUID             `gorm:"column:organization_id"`
 	BedID          *uuid.UUID            `gorm:"column:bed_id;default:NULL"`
-	Tasks          []taskModels.Task     `gorm:"column:foreignKey:PatientId"`
+	Tasks          []taskModels.Task     `gorm:"foreignKey:PatientId"`
 	IsDischarged   soft_delete.DeletedAt `gorm:"column:is_discharged;softDelete:flag;default:0"`
 }


### PR DESCRIPTION
Fixes the following error during `/proto.services.task_svc.v1.WardService/GetWardOverviews`
`ERROR: column patients.foreignKey:PatientId does not exist (SQLSTATE 42703)`