### PR TITLE
feat: optional fallback for X-Organization header

### DIFF
--- a/libs/common/setup.go
+++ b/libs/common/setup.go
@@ -66,7 +66,7 @@ func Setup(serviceName, version string, auth bool) {
 			if err != nil {
 				log.Fatal().Err(err).Msg("invalid uuid for environment variable ORGANIZATION_ID")
 			}
-			log.Info().Str("organizationID", organizationID.String()).Msg("specified fallback organizationID when no organization header was found")
+			log.Info().Str("organizationID", organizationID.String()).Msg("specified fallback organizationID for requests without organization header")
 			InstanceOrganizationID = &organizationID
 		}
 

--- a/libs/common/setup.go
+++ b/libs/common/setup.go
@@ -3,6 +3,7 @@ package common
 import (
 	"crypto/tls"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/joho/godotenv"
 	"github.com/rs/zerolog/log"
 	"hwutil"
@@ -16,6 +17,7 @@ import (
 var (
 	Mode                    string // Mode is set in Setup()
 	InsecureFakeTokenEnable = false
+	OrganizationID          *uuid.UUID
 )
 
 const DevelopmentMode = "development"
@@ -57,6 +59,12 @@ func Setup(serviceName, version string, auth bool) {
 		}
 
 		setupAuth()
+	}
+
+	organizationIdStr := hwutil.GetEnvOr("ORGANIZATION_ID", "")
+	if organizationIdStr != "" {
+		organizationID := uuid.MustParse(organizationIdStr)
+		OrganizationID = &organizationID
 	}
 }
 

--- a/libs/common/setup.go
+++ b/libs/common/setup.go
@@ -63,7 +63,11 @@ func Setup(serviceName, version string, auth bool) {
 
 	organizationIdStr := hwutil.GetEnvOr("ORGANIZATION_ID", "")
 	if organizationIdStr != "" {
-		organizationID := uuid.MustParse(organizationIdStr)
+		organizationID, err := uuid.Parse(organizationIdStr)
+		if err != nil {
+			log.Fatal().Err(err).Msg("invalid uuid for environment variable ORGANIZATION_ID")
+		}
+		log.Info().Str("organizationID", organizationID.String()).Msg("using fallback organizationID")
 		OrganizationID = &organizationID
 	}
 }

--- a/libs/common/setup.go
+++ b/libs/common/setup.go
@@ -17,7 +17,7 @@ import (
 var (
 	Mode                    string // Mode is set in Setup()
 	InsecureFakeTokenEnable = false
-	OrganizationID          *uuid.UUID
+	InstanceOrganizationID  *uuid.UUID
 )
 
 const DevelopmentMode = "development"
@@ -58,17 +58,19 @@ func Setup(serviceName, version string, auth bool) {
 			log.Error().Msg("INSECURE_FAKE_TOKEN_ENABLE is set to true, accepting fake tokens")
 		}
 
-		setupAuth()
-	}
-
-	organizationIdStr := hwutil.GetEnvOr("ORGANIZATION_ID", "")
-	if organizationIdStr != "" {
-		organizationID, err := uuid.Parse(organizationIdStr)
-		if err != nil {
-			log.Fatal().Err(err).Msg("invalid uuid for environment variable ORGANIZATION_ID")
+		// organizationIdStr, later InstanceOrganizationID is used as a fallback when a client does not send the organization header
+		// For code consistency purposes, we are parsing organizationIdStr from a string into a UUID
+		organizationIdStr := hwutil.GetEnvOr("ORGANIZATION_ID", "")
+		if organizationIdStr != "" {
+			organizationID, err := uuid.Parse(organizationIdStr)
+			if err != nil {
+				log.Fatal().Err(err).Msg("invalid uuid for environment variable ORGANIZATION_ID")
+			}
+			log.Info().Str("organizationID", organizationID.String()).Msg("specified fallback organizationID when no organization header was found")
+			InstanceOrganizationID = &organizationID
 		}
-		log.Info().Str("organizationID", organizationID.String()).Msg("using fallback organizationID")
-		OrganizationID = &organizationID
+
+		setupAuth()
 	}
 }
 


### PR DESCRIPTION
## Which issues does this pull request close?
closes #336 

This pull request defines the `X-Organization` header as optional (previous required) for clients. When the header is not passed in the request and a fallback was passed on startup via an environment variable, this env will be used. If both, header and env, are not set, the request fails like before.

## [OPTIONAL] Give testing instructions to reviewers
