### PR TITLE
feat: make rooms cascade delete

### DIFF
--- a/services/task-svc/migrations/000016_room_ward_id_fk.down.sql
+++ b/services/task-svc/migrations/000016_room_ward_id_fk.down.sql
@@ -1,0 +1,3 @@
+-- remove constraint
+ALTER TABLE IF EXISTS rooms
+	DROP CONSTRAINT IF EXISTS rooms_ward_id_fk;

--- a/services/task-svc/migrations/000016_room_ward_id_fk.up.sql
+++ b/services/task-svc/migrations/000016_room_ward_id_fk.up.sql
@@ -1,0 +1,10 @@
+-- unassign conflicting rooms from ward
+DELETE FROM rooms
+WHERE ward_id NOT IN (SELECT id FROM wards);
+
+-- add constraint
+ALTER TABLE rooms
+	ADD CONSTRAINT rooms_ward_id_fk
+	FOREIGN KEY (ward_id)
+	REFERENCES wards (id)
+	ON DELETE CASCADE;


### PR DESCRIPTION
## Which issues does this pull request close?
closes #372

## [OPTIONAL] Give testing instructions to reviewers
```
./migrate up 15
psql ...
INSERT INTO wards VALUES ('66a46bf8-bc96-462e-918c-7e325721513b', 'Ward', '3b25c6f5-4705-4074-9fc6-a50c28eba406');
INSERT INTO rooms VALUES ('244a3086-70cb-47a7-8033-bfc8704ea90e', 'Room', '3b25c6f5-4705-4074-9fc6-a50c28eba406', '66a46bf8-bc96-462e-918c-7e325721513b');
INSERT INTO rooms VALUES ('d4e4ea0e-dcf7-4e85-ad4a-6700c939e210', 'Room 2', '3b25c6f5-4705-4074-9fc6-a50c28eba406', '76a46bf8-bc96-462e-918c-7e325721513b');
./migrate up 1
./migrate down 1

```
