### PR TITLE
fix setup-go's cache

### DIFF
--- a/.github/workflows/ci-go-libs.yaml
+++ b/.github/workflows/ci-go-libs.yaml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/*.sum"
 
       - uses: actions/checkout@v4
 
@@ -46,6 +47,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/*.sum"
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/cicd-go.yaml
+++ b/.github/workflows/cicd-go.yaml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/*.sum"
 
       - uses: actions/checkout@v4
 
@@ -59,6 +60,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/*.sum"
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
see https://github.com/actions/setup-go?tab=readme-ov-file#caching-dependency-files-and-build-outputs

## Which issues does this pull request close?
closes #352

