### PR TITLE
ci: re-build all images when "lib" changes

### DIFF
--- a/.github/workflows/cicd-images.yaml
+++ b/.github/workflows/cicd-images.yaml
@@ -68,7 +68,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Build

--- a/.github/workflows/cicd-images.yaml
+++ b/.github/workflows/cicd-images.yaml
@@ -68,7 +68,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ github.token }}
 
       - name: Build

--- a/.github/workflows/cicd-images.yaml
+++ b/.github/workflows/cicd-images.yaml
@@ -72,6 +72,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Build
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: images/${{ inputs.image }}
@@ -90,4 +91,4 @@ jobs:
       - name: Check manifest
         if: inputs.deploy
         run: |
-          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -62,6 +62,8 @@ jobs:
       - name: Aggregate changes
         id: aggregate-changes
         run: |
+          echo "images=$(echo $changesInImages | awk -F / '$1 ~ /images/ {print $2}' | uniq | grep -v dev-go-custom | jq -R . | jq -sc .)" >> $GITHUB_OUTPUT
+
           if [[ "$libsChanged" == "true" ]]; then
             # Exception for the Python "impulse_svc". Our workflows are very Golang opinionated.
             echo "services=$(ls services | grep -v 'impulse_svc' | uniq | jq -R . | jq -sc .)" >> $GITHUB_OUTPUT
@@ -69,10 +71,11 @@ jobs:
             # Exception for "libs/proto_helpers" due to the fact that this package does not require any direct external packages.
             # If the CI runs "go get .", the command exits (1) with "go: .: no package to get in current directory".
             echo "libs=$(ls libs | grep -v -e 'python' -e 'proto_helpers' | uniq | jq -R . | jq -sc .)" >> $GITHUB_OUTPUT
+
+            echo "images=$(ls images | grep -v dev-go-custom | uniq | jq -R . | jq -sc .)" >> $GITHUB_OUTPUT
           else
             echo "services=$(echo $changesInServices | awk -F / '$1 ~ /services/ {print $2}' | uniq | jq -R . | jq -sc .)" >> $GITHUB_OUTPUT
           fi
-          echo "images=$(echo $changesInImages | awk -F / '$1 ~ /images/ {print $2}' | uniq | grep -v dev-go-custom | jq -R . | jq -sc .)" >> $GITHUB_OUTPUT
         env:
           libsChanged: ${{ steps.changes-in-libs.outputs.any_changed }}
           changesInServices: ${{ steps.changes-in-services.outputs.all_changed_files }}


### PR DESCRIPTION
- If libs (e. g. `.github/`) changes, we try to re-build our images. Mostly to test our CI.
- Check against `${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}` instead of tags due to tag logic during build, see https://github.com/helpwave/services/actions/runs/8117770096/job/22205817398