### PR TITLE
chore: add `FEATURE_FLAG_HWAUTHZ_SPICEDB_CHECKS_ALWAYS_TRUE`

### DIFF
--- a/libs/hwauthz/README.md
+++ b/libs/hwauthz/README.md
@@ -4,3 +4,9 @@
 
 Provides an SDK for Fine-Grained Authorization using a [Zanzibar](https://zanzibar.academy/)-like provider ([SpiceDB](https://authzed.com/docs/spicedb/getting-started/discovering-spicedb)).
 
+## Feature flags
+
+- `FEATURE_FLAG_HWAUTHZ_SPICEDB_CHECKS_ALWAYS_TRUE`
+
+  The SpiceDB implementation of hwauthz.AuthZ.Check() returns always true when this flag is set to true
+	

--- a/libs/hwauthz/authz.go
+++ b/libs/hwauthz/authz.go
@@ -9,6 +9,10 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
+const (
+	FeatureFlagHWAuthZSpiceDBChecksAlwaysTrue = "FEATURE_FLAG_HWAUTHZ_SPICEDB_CHECKS_ALWAYS_TRUE"
+)
+
 // StatusErrorPermissionDenied should be returned when a necessary permission check has failed
 func StatusErrorPermissionDenied(ctx context.Context, check Relationship) error {
 	msg := fmt.Sprintf(

--- a/libs/hwauthz/spicedb/spicedb.go
+++ b/libs/hwauthz/spicedb/spicedb.go
@@ -7,6 +7,7 @@ import (
 	"github.com/authzed/authzed-go/v1"
 	"github.com/authzed/grpcutil"
 	zlog "github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"hwauthz"
@@ -111,6 +112,11 @@ func (s *SpiceDBAuthZ) Check(ctx context.Context, permissionCheck hwauthz.Permis
 	defer span.End()
 
 	telemetry.SetSpanAttributes(ctx, permissionCheck.SpanAttributeKeyValue()...)
+
+	if hwutil.HasEnv(hwauthz.FeatureFlagHWAuthZSpiceDBChecksAlwaysTrue) {
+		span.SetAttributes(attribute.KeyValue{Key: hwauthz.FeatureFlagHWAuthZSpiceDBChecksAlwaysTrue, Value: attribute.BoolValue(true)})
+		return true, nil
+	}
 
 	// convert internal Representation to gRPC body
 	req := &v1.CheckPermissionRequest{


### PR DESCRIPTION
This pull requests adds the feature flag `FEATURE_FLAG_HWAUTHZ_SPICEDB_CHECKS_ALWAYS_TRUE` for `hwauthz`. Currently we do not have a prod/staging ready SpiceDB config.

The feature flag is already set for `tasks-svc`